### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "semantic-release": "^25.0.6",
+    "semantic-release": "^25.0.7",
     "@team-internet/semantic-release-plugins": "^1.0.7"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     devDependencies:
       '@semantic-release/changelog':
         specifier: ^6.0.3
-        version: 6.0.3(semantic-release@25.0.6)
+        version: 6.0.3(semantic-release@25.0.7)
       '@semantic-release/git':
         specifier: ^10.0.1
-        version: 10.0.1(semantic-release@25.0.6)
+        version: 10.0.1(semantic-release@25.0.7)
       '@team-internet/semantic-release-plugins':
         specifier: ^1.0.7
         version: 1.0.7
       semantic-release:
-        specifier: ^25.0.6
-        version: 25.0.6
+        specifier: ^25.0.7
+        version: 25.0.7
 
 packages:
 
@@ -1025,8 +1025,8 @@ packages:
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
-  semantic-release@25.0.6:
-    resolution: {integrity: sha512-EGS5PWCDavYD4jAE4vKQ+VKcwXFpxLsKg05UcrUQwqxUCM1KtNRx9ZdMyYJL3z2aTyAH9zDgQSNFjRvbsIuKHQ==}
+  semantic-release@25.0.7:
+    resolution: {integrity: sha512-fFiUD7LNFI0TOGkc49WDHUX4GYKrOMDKct5ReSB1EJCZiPsPdbIPIJGys1xb2ILpK1v9JMsRkjJQgTRpbr7DgQ==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
 
@@ -1400,15 +1400,15 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.6)':
+  '@semantic-release/changelog@6.0.3(semantic-release@25.0.7)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
       fs-extra: 11.3.6
       lodash: 4.18.1
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.6)':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.7)':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -1418,7 +1418,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
     transitivePeerDependencies:
       - supports-color
 
@@ -1426,7 +1426,7 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/git@10.0.1(semantic-release@25.0.6)':
+  '@semantic-release/git@10.0.1(semantic-release@25.0.7)':
     dependencies:
       '@semantic-release/error': 3.0.0
       aggregate-error: 3.1.0
@@ -1436,11 +1436,11 @@ snapshots:
       lodash: 4.18.1
       micromatch: 4.0.8
       p-reduce: 2.1.0
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.9(semantic-release@25.0.6)':
+  '@semantic-release/github@12.0.9(semantic-release@25.0.7)':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -1456,7 +1456,7 @@ snapshots:
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
       tinyglobby: 0.2.17
       undici: 7.28.0
       url-join: 5.0.0
@@ -1464,7 +1464,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.6)':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.7)':
     dependencies:
       '@actions/core': 3.0.1
       '@semantic-release/error': 4.0.0
@@ -1479,11 +1479,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
       semver: 7.8.5
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.6)':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.7)':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -1493,7 +1493,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 25.0.6
+      semantic-release: 25.0.7
     transitivePeerDependencies:
       - supports-color
 
@@ -2242,13 +2242,13 @@ snapshots:
 
   safe-buffer@5.1.2: {}
 
-  semantic-release@25.0.6:
+  semantic-release@25.0.7:
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.6)
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.7)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.9(semantic-release@25.0.6)
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.6)
-      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.6)
+      '@semantic-release/github': 12.0.9(semantic-release@25.0.7)
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.7)
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.7)
       aggregate-error: 5.0.0
       cosmiconfig: 9.0.2
       debug: 4.4.3


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass