### PR TITLE
chore(deps): refresh node dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "semantic-release": "^25.0.8",
-    "@team-internet/semantic-release-plugins": "^1.4.2"
+    "@team-internet/semantic-release-plugins": "^1.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(semantic-release@25.0.8(supports-color@7.2.0))(supports-color@7.2.0)
       '@team-internet/semantic-release-plugins':
-        specifier: ^1.4.2
-        version: 1.4.2(semantic-release@25.0.8(supports-color@7.2.0))
+        specifier: ^1.5.0
+        version: 1.5.0(semantic-release@25.0.8(supports-color@7.2.0))
       semantic-release:
         specifier: ^25.0.8
         version: 25.0.8(supports-color@7.2.0)
@@ -166,8 +166,8 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
-  '@team-internet/semantic-release-plugins@1.4.2':
-    resolution: {integrity: sha512-oYmQE51he/2xccmgDYikecNO7DGnLIzLrSPHULwsK/DJ5KTgDJ/u5O5EmtWmdiSdyCjixFU6kM6QZiyZWDyglg==}
+  '@team-internet/semantic-release-plugins@1.5.0':
+    resolution: {integrity: sha512-2d0HscXjtZ1ZchKWvvQu42+DuxuIPWnBdRmv3oxFKLXgprTQMHnrt77dwTNe9ae9iK1Pg6gHD3dTFfwzTOn5Tg==}
     engines: {node: ^22.14.0 || >=24.10.0}
     peerDependencies:
       prettier: '>=3'
@@ -1661,7 +1661,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@team-internet/semantic-release-plugins@1.4.2(semantic-release@25.0.8(supports-color@7.2.0))':
+  '@team-internet/semantic-release-plugins@1.5.0(semantic-release@25.0.8(supports-color@7.2.0))':
     dependencies:
       '@semantic-release/error': 4.0.0
       archiver: 8.0.0


### PR DESCRIPTION
## Summary
- update package.json with npm-check-updates patch and minor releases
- remove pnpm install state and regenerate pnpm-lock.yaml with pnpm update
- allow the test workflow to enable auto-merge after checks pass