### PR TITLE
fix(idna): make transitional IDNA processing reachable and correctly named

### DIFF
--- a/src/IDNA/Converter/ASCIIConverter.php
+++ b/src/IDNA/Converter/ASCIIConverter.php
@@ -18,12 +18,16 @@ final class ASCIIConverter implements ConversionInterface
     #[\Override]
     public static function convert(string $keyword, array $options): string
     {
-        $transitionalProcessing = ConverterFactory::transitionalProcessing($keyword, $options);
+        $transitional = ConverterFactory::transitionalProcessing($keyword, $options);
+
+        if ($transitional) {
+            $keyword = ConverterFactory::applyTransitionalMapping($keyword);
+        }
 
         // Convert domain to Punycode
         $punycode = idn_to_ascii(
             $keyword,
-            $transitionalProcessing ? IDNA_NONTRANSITIONAL_TO_ASCII : IDNA_DEFAULT,
+            IDNA_NONTRANSITIONAL_TO_ASCII,
             INTL_IDNA_VARIANT_UTS46
         );
 

--- a/src/IDNA/Converter/UnicodeConverter.php
+++ b/src/IDNA/Converter/UnicodeConverter.php
@@ -18,11 +18,16 @@ final class UnicodeConverter implements ConversionInterface
     #[\Override]
     public static function convert(string $keyword, array $options): string
     {
-        $transitionalProcessing = ConverterFactory::transitionalProcessing($keyword, $options);
+        $transitional = ConverterFactory::transitionalProcessing($keyword, $options);
+
+        $decoded = self::decode($keyword);
+        if ($transitional) {
+            $decoded = ConverterFactory::applyTransitionalMapping($decoded);
+        }
 
         $idn = idn_to_utf8(
-            self::decode($keyword),
-            $transitionalProcessing ? IDNA_NONTRANSITIONAL_TO_UNICODE : IDNA_DEFAULT,
+            $decoded,
+            IDNA_NONTRANSITIONAL_TO_UNICODE,
             INTL_IDNA_VARIANT_UTS46
         );
 

--- a/src/IDNA/Factory/ConverterFactory.php
+++ b/src/IDNA/Factory/ConverterFactory.php
@@ -82,9 +82,11 @@ final class ConverterFactory
 
         foreach ($domainArray as &$tmpKeyword) {
             if (ASCIIConverter::check($tmpKeyword)) {
+                // Already-decoded output must not be run through conversion again below:
+                // re-converting it would re-apply transitional mapping to a result that
+                // is already final, corrupting it (e.g. "faß" would become "fass").
                 $tmpKeyword = UnicodeConverter::convert($tmpKeyword, $options);
-            }
-            if (UnicodeConverter::containsUnicodeCharacters($tmpKeyword)) {
+            } elseif (UnicodeConverter::containsUnicodeCharacters($tmpKeyword)) {
                 $tmpKeyword = UnicodeConverter::decode($tmpKeyword);
                 $tmpKeyword = UnicodeConverter::convert($tmpKeyword, $options);
             }
@@ -165,11 +167,11 @@ final class ConverterFactory
     }
 
     /**
-     * Check if the provided top-level domain (TLD) is non-transitional.
+     * Determine whether transitional IDNA processing should be applied to the given domain.
      *
      * @param string $keyword The domain string to check.
      * @param array<string, mixed> $options Additional options for the conversion process.
-     * @return bool Returns true if the TLD is non-transitional, false otherwise.
+     * @return bool Returns true if transitional processing should be applied, false for non-transitional processing.
      *
      * @api
      */
@@ -183,9 +185,33 @@ final class ConverterFactory
             ? $options["domain"]
             : $keyword;
 
-        return mb_eregi(
+        // These ccTLD registries require non-transitional processing (deviation characters kept as-is).
+        return !mb_eregi(
             "\.(art|be|ca|de|fr|pm|re|swiss|tf|wf|yt)\.?$",
             $domain
         );
+    }
+
+    /**
+     * Map UTS46 "deviation" characters to their transitional-processing equivalents.
+     *
+     * Current ICU versions no longer distinguish IDNA_DEFAULT from
+     * IDNA_NONTRANSITIONAL_TO_ASCII/TO_UNICODE, so transitional processing is
+     * implemented here explicitly rather than delegated to ICU, keeping
+     * results stable across ICU versions.
+     *
+     * @param string $keyword The keyword to map.
+     * @return string The keyword with deviation characters mapped.
+     *
+     * @internal
+     */
+    public static function applyTransitionalMapping(string $keyword): string
+    {
+        return strtr($keyword, [
+            "\u{00DF}" => "ss",
+            "\u{03C2}" => "\u{03C3}",
+            "\u{200C}" => "",
+            "\u{200D}" => "",
+        ]);
     }
 }

--- a/tests/IDNATranslatorTest.php
+++ b/tests/IDNATranslatorTest.php
@@ -37,20 +37,20 @@ final class IDNATranslatorTest extends TestCase
             'x\u0301\u0327.de' => 'xn--x-xbb7i.de',
             'عربي.de' => 'xn--ngbrx4e.de',
             'نامهای.de' => 'xn--mgba3gch31f.de',
-            'fäß.de' => 'xn--f-qfao.de',
-            'faß.de' => 'xn--fa-hia.de',
+            'fäß.de' => 'xn--fss-qla.de',
+            'faß.de' => 'fass.de',
             'xn--fa-hia.de' => 'xn--fa-hia.de',
-            'σόλος.gr' => 'xn--wxaijb9b.gr',
-            'Σόλος.gr' => 'xn--wxaijb9b.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de' => 'xn--wxaijb9b.xn--gr-gtd9a1b0g.de',
-            'نامه\u200Cای.de' => 'xn--mgba3gch31f060k.de',
-        ],
-        'toAsciiWithoutTransitional' => [
             'σόλος.gr' => 'xn--wxaikc6b.gr',
             'Σόλος.gr' => 'xn--wxaikc6b.gr',
             'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de' => 'xn--wxaikc6b.xn--gr-gtd9a1b0g.de',
-            'fäß.de' => 'xn--fss-qla.de',
-            'faß.de' => 'fass.de',
+            'نامه\u200Cای.de' => 'xn--mgba3gch31f.de',
+        ],
+        'toAsciiWithoutTransitional' => [
+            'σόλος.gr' => 'xn--wxaijb9b.gr',
+            'Σόλος.gr' => 'xn--wxaijb9b.gr',
+            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de' => 'xn--wxaijb9b.xn--gr-gtd9a1b0g.de',
+            'fäß.de' => 'xn--f-qfao.de',
+            'faß.de' => 'xn--fa-hia.de',
             'xn--bb-eka.at' => 'xn--bb-eka.at',
             'XN--BB-EKA.AT' => 'xn--bb-eka.at',
             'fass.de' => 'fass.de',
@@ -69,6 +69,7 @@ final class IDNATranslatorTest extends TestCase
             'x\u0301\u0327.de' => 'xn--x-xbb7i.de',
             'عربي.de' => 'xn--ngbrx4e.de',
             'نامهای.de' => 'xn--mgba3gch31f.de',
+            'نامه\u200Cای.de' => 'xn--mgba3gch31f060k.de',
         ],
         'toUnicode' => [
             '' => '',
@@ -77,7 +78,7 @@ final class IDNATranslatorTest extends TestCase
             'ÖBB.at' => 'öbb.at',
             'O\u0308bb.at' => 'öbb.at',
             'xn--bb-eka.at' => 'öbb.at',
-            'faß.de' => 'faß.de',
+            'faß.de' => 'fass.de',
             'fass.de' => 'fass.de',
             'xn--fa-hia.de' => 'faß.de',
             'not=std3' => 'not=std3',
@@ -87,11 +88,11 @@ final class IDNATranslatorTest extends TestCase
             //'\ud83d\udca9' => '\ud83d\udca9',
             //'\ud87e\udcca' => '\ud84c\udc0a',
             //'\udb40\udd00\ud87e\udcca' => '\ud84c\udc0a',
-            'fäß.de' => 'fäß.de',
+            'fäß.de' => 'fäss.de',
             '₹.com' => '₹.com',
             '𑀓.com' => '𑀓.com',
             //'a‌b' => 'a\u200Cb',
-            'a‌b' => 'a‌b',
+            'a‌b' => 'ab',
             'xn--ab-j1t' => 'a‌b',
             'ȡog.de' => 'ȡog.de',
             '☕.de' => '☕.de',
@@ -101,12 +102,12 @@ final class IDNATranslatorTest extends TestCase
             '日本｡co．jp' => '日本.co.jp',
             'x\u0327\u0301.de' => 'x̧́.de',
             'x\u0301\u0327.de' => 'x̧́.de',
-            'σόλος.gr' => 'σόλος.gr',
-            'Σόλος.gr' => 'σόλος.gr',
-            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de' => 'σόλος.grعربي.de',
+            'σόλος.gr' => 'σόλοσ.gr',
+            'Σόλος.gr' => 'σόλοσ.gr',
+            'ΣΌΛΟΣ.grﻋﺮﺑﻲ.de' => 'σόλοσ.grعربي.de',
             'عربي.de' => 'عربي.de',
             'نامهای.de' => 'نامهای.de',
-            'نامه\u200Cای.de' => 'نامه‌ای.de',
+            'نامه\u200Cای.de' => 'نامهای.de',
         ],
     ];
 
@@ -233,7 +234,7 @@ final class IDNATranslatorTest extends TestCase
         ];
 
         foreach ($nonTransitionalDomains as $domain) {
-            $this->assertTrue(ConverterFactory::transitionalProcessing($domain), $domain);
+            $this->assertFalse(ConverterFactory::transitionalProcessing($domain), $domain);
         }
 
         $transitionalDomains = [
@@ -245,10 +246,27 @@ final class IDNATranslatorTest extends TestCase
         ];
 
         foreach ($transitionalDomains as $domain) {
-            $this->assertFalse(ConverterFactory::transitionalProcessing($domain), $domain);
+            $this->assertTrue(ConverterFactory::transitionalProcessing($domain), $domain);
         }
 
-        $this->assertTrue(ConverterFactory::transitionalProcessing('münchen', ['domain' => 'münchen.de']));
+        $this->assertFalse(ConverterFactory::transitionalProcessing('münchen', ['domain' => 'münchen.de']));
+    }
+
+    // Conformance fixture cross-checked against an independent UTS46 implementation
+    // so this library's transitional-processing behaviour cannot drift unnoticed.
+    // See RSRMID-2979.
+    public function testKnownConformanceVectors(): void
+    {
+        $cases = [
+            'faß.com' => 'fass.com',
+            'θεός.gr' => 'xn--qxaf8a9a.gr',
+            'straße.de' => 'xn--strae-oqa.de',
+            'münchen.de' => 'xn--mnchen-3ya.de',
+        ];
+
+        foreach ($cases as $input => $expected) {
+            $this->assertEquals($expected, ConverterFactory::toASCII($input), $input);
+        }
     }
 
     // Test cases for converting domain names to Unicode
@@ -261,6 +279,45 @@ final class IDNATranslatorTest extends TestCase
                 "{$input} : {$output}"
             );
         }
+    }
+
+    // The transitionalProcessing option must also be honored when decoding to
+    // Unicode, not just when encoding to Punycode: deviation characters (ß, ς,
+    // ZWNJ, ZWJ) present directly in the input should be mapped under
+    // transitional processing and left as-is under non-transitional processing.
+    public function testToUnicodeTransitionalOption(): void
+    {
+        $cases = [
+            'faß.de' => ['fass.de', 'faß.de'],
+            'fäß.de' => ['fäss.de', 'fäß.de'],
+            'σόλος.gr' => ['σόλοσ.gr', 'σόλος.gr'],
+            'Σόλος.gr' => ['σόλοσ.gr', 'σόλος.gr'],
+            'نامه‌ای.de' => ['نامهای.de', 'نامه‌ای.de'],
+        ];
+
+        foreach ($cases as $input => [$withTransition, $withoutTransition]) {
+            $this->assertEquals(
+                $withTransition,
+                ConverterFactory::toUnicode($input, ["transitionalProcessing" => true]),
+                "{$input} (transitional)"
+            );
+            $this->assertEquals(
+                $withoutTransition,
+                ConverterFactory::toUnicode($input, ["transitionalProcessing" => false]),
+                "{$input} (non-transitional)"
+            );
+        }
+
+        // Decoding an already-encoded Punycode label is unaffected by the option:
+        // the deviation mapping only ever applies to literal Unicode input.
+        $this->assertEquals(
+            'faß.de',
+            ConverterFactory::toUnicode('xn--fa-hia.de', ["transitionalProcessing" => true])
+        );
+        $this->assertEquals(
+            'faß.de',
+            ConverterFactory::toUnicode('xn--fa-hia.de', ["transitionalProcessing" => false])
+        );
     }
 
     // Single-label (no TLD) keyword whose escaped Unicode decodes to characters


### PR DESCRIPTION
ASCIIConverter::convert() picked between IDNA_DEFAULT and IDNA_NONTRANSITIONAL_TO_ASCII, but current ICU versions no longer distinguish them, so the transitional/non-transitional selection was a no-op and transitional output was unreachable. Transitional processing (mapping ß->ss, ς->σ, and dropping ZWNJ/ZWJ) is now applied explicitly via ConverterFactory::applyTransitionalMapping() before always calling ICU with the non-transitional flag, so results no longer depend on the installed ICU version.

UnicodeConverter::convert() had the same ICU dependency on the decode side. Restoring transitional handling there also exposed a latent bug in ConverterFactory::toUnicode(): its per-label loop could run an already-decoded Punycode label through conversion a second time, which would corrupt results once transitional mapping was reintroduced (e.g. "faß" becoming "fass"). The loop now converts each label at most once.

ConverterFactory::transitionalProcessing() returned the opposite of what its name and the transitionalProcessing option promised (true meant non-transitional). It now returns true when transitional processing should be applied.

Added conformance fixtures cross-checked against an independent UTS46 implementation, plus coverage for the transitionalProcessing option on the decode path, which was previously untested.

BREAKING CHANGE: ConverterFactory::transitionalProcessing() now returns true when transitional processing applies (previously true meant non-transitional). Callers relying on the old inverted meaning, or expecting the transitionalProcessing option to have no effect, must review their usage.

Refs: RSRMID-2979