### PR TITLE
fix(packaging): ship LICENSE and composer.json, drop dev-only archive weight

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,14 +4,17 @@
 # directories to exclude
 .devcontainer export-ignore
 .github export-ignore
+docs export-ignore
 reports export-ignore
 tests export-ignore
 
 # files to exclude
 .releaserc.json export-ignore
-composer.json export-ignore
+HISTORY.md export-ignore
+package.json export-ignore
 phpdoc.dist.xml export-ignore
 phpunit.xml.dist export-ignore
+pnpm-lock.yaml export-ignore
 *.sh export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -16,6 +16,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Assert distribution archive contents
+        run: |
+          expected=$(printf '%s\n' 'LICENSE' 'README.md' 'composer.json' 'src/' | sort)
+          actual=$(git archive HEAD | tar -t | awk -F/ '{print $1 (NF>1 ? "/" : "")}' | sort -u)
+          if [ "$expected" != "$actual" ]; then
+            echo "::error::Distribution archive top-level contents changed."
+            echo "Expected:"; echo "$expected"
+            echo "Actual:"; echo "$actual"
+            exit 1
+          fi
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 Team Internet Group PLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The IDN Converter PHP Library provides a simple and efficient solution for conve
 
 - PHP 8.3 or higher
 - `ext-intl`, `ext-mbstring` and `ext-json`
+- `ext-mbstring` must be built with the mbregex (oniguruma) option enabled. Composer cannot express this narrower requirement, so on a PHP build compiled with `--disable-mbregex`, `ext-mbstring` is present but conversion fails on an undefined `mb_ereg`. Every mainstream distro build of PHP includes mbregex.
 
 ## Installation
 


### PR DESCRIPTION
The Composer distribution archive shipped no LICENSE and no composer.json, so an MIT declaration existed only as Packagist metadata and nothing in vendor/ satisfied SBOM/licence scanners that read composer.json directly. Meanwhile generated API docs, the Node tooling manifest and its lockfile, and the changelog were shipped for no runtime benefit.

- Add a root LICENSE (MIT, Team Internet Group PLC).
- Remove the composer.json export-ignore line so it ships.
- Add export-ignore for docs/, package.json, pnpm-lock.yaml and HISTORY.md.
- Add a CI step asserting the archive's top-level contents are exactly composer.json, LICENSE, README.md and src/, so a future dev-only root file can't silently leak into the dist archive again.
- Document the mbregex (oniguruma) build requirement for ext-mbstring in the README, since Composer's ext-mbstring constraint can't express it and a build without it fails at runtime on mb_ereg().

No version-constraint change for consumers; packaging only.

Refs: RSRMID-2981