### PR TITLE
ci(release): pin repositoryUrl to the SSH form

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+    "repositoryUrl": "git@github.com:centralnicgroup-opensource/rtldev-middleware-php-idna-translator.git",
     "branches": ["main"],
     "plugins": [
         "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Jira: https://centralnic.atlassian.net/browse/RSRMID-2994

Pins `repositoryUrl` to the `git@` form so the release push goes over SSH with this repository's deploy key.

### Why this one line is not optional

`semantic-release` expands the repository URL before SSH is ever attempted — `lib/get-git-auth-url.js`:

```js
if (info && info.getDefaultRepresentation() === "shortcut") {
    repositoryUrl = info.https();          // github:owner/repo  ->  https://...
}
await verifyAuth(repositoryUrl, branch.name, ...);
```

Without an explicit `repositoryUrl` the value comes from `package.json` (a `github:` shortcut) or from the checkout's `origin` (HTTPS). Either way it resolves to HTTPS and SSH is never tried, so the push would keep using the personal access token — and the ruleset, whose only bypass actor is `DeployKey`, would reject it.

### The other halves of the change

- **the key** — this repository now has exactly one write-enabled deploy key, titled `semantic-release`, whose private half is the repository secret `RTLDEV_MW_CI_SSH_KEY`. Exactly one matters: GitHub grants the ruleset bypass to deploy keys as a class, not to one key.
- **the workflow** — centralnicgroup-opensource/rtldev-middleware-shareable-workflows#110 adds the SSH setup step to the reusable release workflow this repository calls.
- **the protection swap** — the default-branch ruleset gets enabled with the `DeployKey::always` bypass, and classic branch protection is removed in the same step. Classic protection requires a pull request and exempts only admins, so it would reject a deploy key where it accepts today's admin PAT. The ruleset is the stricter of the two: it adds linear history and binds admins as well.

`GITHUB_TOKEN` stays in the release step — `@semantic-release/github` still needs it to create the GitHub release. Only the git push moves.